### PR TITLE
docs: add CHANGELOG + deployment guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This
+project adheres to a pre-1.0 cadence: minor bumps are breaking/notable, patch
+bumps are additive or fixes. Dates are in `YYYY-MM-DD`.
+
+## [Unreleased]
+
+Nothing yet.
+
+## [0.2.0] — 2026-04-21
+
+First tagged release post-MVP. The pipeline is end-to-end production-quality
+on the default MiniMax M2.7 model, with real image attachment gated by CLIP +
+alt-quality + vision-LLM rerank.
+
+### Added
+
+- **PDF export** via `scripts/mkpdf.mjs` (Chromium headless print-to-PDF) —
+  weasyprint's CJK output was garbled on macOS Preview, Chromium's Type 3
+  font embedding is cross-reader stable. Remote images are downloaded into
+  `out/_pdf_assets/` first so the PDF is offline-reproducible.
+- **CLIP warm-up** (#26) — `warmClipModel` fire-and-forget from
+  `runTopic2md` / `regenSection` entry; cuts cold-start from ~114s to ~1.4s
+  when the Replicate container is still warm from a prior run.
+- **Persistent image embeddings** (#27) — `image_embeddings(url,
+model_version, embedding BLOB)` table in SQLite caches jina-clip-v2
+  embeddings across runs. 100% cache-hit on regen of prior runs; ~$0.17/run
+  → near-zero for recurring URLs.
+- **Alt-quality penalty** (#28) — soft multiplier on raw CLIP cosine for
+  empty/generic alt, short alt, and CMS-dump upload-path URLs.
+- **CLIP relevance gate** — `zsxkib/jina-clip-v2` on Replicate, threshold
+  0.30 calibrated on 68 labeled candidates (AUC 0.85, recall 0.97,
+  kills ~60% irrelevant). `REPLICATE_API_TOKEN` optional; absent ⇒ bypass.
+- **Candidate pool + vision rerank** — all image plugins contribute
+  candidates; qwen3-vl-32b picks one per section. `pickIndex = -1` is
+  respected — no keyword fallback when vision deliberately rejects.
+- **Background context field** (#24) — `WorkflowInput.background`
+  (freeform) threads through research → outline → sections. Persisted in
+  `runs.background`. CLI `--background` / `--background-file`; Web UI via
+  collapsible textarea. `regen` reuses the source run's background unless
+  overridden.
+- **SQLite persistence** — `runs` + `run_stages` tables record every
+  `runTopic2md` invocation; `topic2md list / show / regen --section N`.
+- **LLM model fallback chain** with per-generation Langfuse telemetry
+  (`generation.*` events).
+- **Plugin `dispose?()`** lifecycle hook — runner calls in `finally` to
+  release Playwright browsers and DB handles.
+
+### Changed
+
+- `generateObject` forced to `mode: 'json'` to avoid the malformed
+  tool-call JSON path on OpenRouter-routed providers (MiniMax/GLM). Cut
+  sections step from ~500s → ~60s.
+- Open-source hygiene overhaul: `CONTRIBUTING.md`, `SECURITY.md`, GitHub
+  issue / PR templates, full English `README.en.md`.
+
+### Fixed
+
+- Outline retries once on first-attempt failure before giving up.
+- Section two-retry failure now renders outline bullets as a bullet-list
+  fallback rather than leaving the section empty.
+- `regen` runId parsing accepts nanoids that start with `-` / `_`
+  (previously filtered by `!arg.startsWith('-')`).
+- Docker image copies the full workspace + installs `build-essential` so
+  `better-sqlite3` can build from source on unusual glibc/node combos.
+- `DATABASE_URL` anchored via `import.meta.url` so Web UI and CLI share one
+  run history regardless of cwd.
+
+## [0.1.0] — ~2026-03
+
+Initial MVP. Mastra workflow skeleton, Tavily source, file publish,
+Playwright screenshot, Next.js trigger UI. Single model, no persistence, no
+regeneration. Historical record only; not tagged.

--- a/README.en.md
+++ b/README.en.md
@@ -236,20 +236,9 @@ services:
 Images are also auto-published to GitHub Container Registry from `main` —
 `ghcr.io/llm-x-factorer/topic2md:main`.
 
-## Sizing a deployment
-
-The workflow is a long synchronous request (60-200s per run) plus Chromium for
-image screenshotting. **Serverless is not a fit** — Vercel / Cloudflare
-Workers / Netlify all have function-timeout limits shorter than a single run.
-
-| Use case                        | Shape                                                                                                                  |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Single-user self-host           | 1 vCPU / 2 GB RAM / 20 GB SSD                                                                                          |
-| Small team, 2-5 concurrent runs | 2-4 vCPU / 4-8 GB RAM / 40 GB SSD                                                                                      |
-| Public SaaS                     | Queue + worker pool. Add rate limits, per-user quotas, and a separate Redis. Don't expose `runTopic2md` synchronously. |
-
-Monthly cost ballpark for the self-host shape: **$15-30** total (VPS + API
-usage at one article/day).
+**Full deployment guide** (sizing tables, API-key budget, reverse proxy with
+TLS, persistent volumes, hardening) — see
+[`docs/deployment.md`](./docs/deployment.md).
 
 ## Integrating with md2wechat (optional)
 
@@ -272,6 +261,8 @@ Everything lives in [GitHub Issues](https://github.com/LLM-X-Factorer/topic2md/i
 - Priority: `p0-blocker` / `p1-important` / `p2-later`
 - Area: `area/web` / `area/core` / `area/plugin` / `area/cli` / `area/infra`
 - Type: `bug` / `enhancement` / `help wanted` / `good first issue`
+
+Release notes and user-facing changes are in [`CHANGELOG.md`](./CHANGELOG.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -196,21 +196,9 @@ docker run --rm -p 3000:3000 \
   topic2md
 ```
 
-最小 docker-compose 参考：
+或直接拉 GHCR 上的已构建镜像：`ghcr.io/llm-x-factorer/topic2md:main`。
 
-```yaml
-services:
-  topic2md:
-    build: .
-    ports: ['3000:3000']
-    environment:
-      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
-      TAVILY_API_KEY: ${TAVILY_API_KEY}
-      LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
-      LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
-    volumes:
-      - ./out:/app/out
-```
+**完整部署指南**（服务器选型、API key 预算、反向代理 + TLS、持久化卷、安全硬化）见 [`docs/deployment.md`](./docs/deployment.md)。
 
 ## 与 md2wechat 集成（可选）
 
@@ -228,6 +216,8 @@ services:
 - `p0-blocker` / `p1-important` / `p2-later` 标优先级
 - `area/web` / `area/core` / `area/plugin` / `area/cli` / `area/infra` 标区域
 - 提新需求或 bug 请直接开 issue，PR 里用 `Closes #N` 关联
+
+版本发布与改动记录见 [`CHANGELOG.md`](./CHANGELOG.md)。
 
 ## 贡献 / 安全问题
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,263 @@
+# Deployment Guide
+
+How to get the `topic2md` Web UI running on a server you control. Covers
+sizing, required accounts, Docker setup, TLS, and hardening.
+
+## Is this for you?
+
+Use this guide if you want to self-host the Web UI (`apps/web`) so yourself
+or a small team can trigger article generation from a browser.
+
+**Not covered here**: running only the CLI (just `pnpm install && pnpm topic2md`
+— see the root README), or running as a managed SaaS (you'd need user auth,
+quota enforcement, and a job queue; all out of scope for v0.2).
+
+## Architecture note: this is NOT serverless-friendly
+
+A single run takes **60-200s** (research → outline → sections with parallel
+LLM calls → image discovery + CLIP gating + vision rerank → assembly).
+Platforms with synchronous function-timeout limits shorter than that don't
+fit, including:
+
+- **Vercel** — 60s default / 300s on Pro (Pro plans edge into feasibility but
+  Chromium for image-screenshot plugin won't run on serverless anyway)
+- **Cloudflare Workers** — no filesystem, no Chromium, no long requests
+- **Netlify Functions** — same story
+
+Use a long-running host: a plain VPS, Fly.io / Railway / Render app container,
+or self-hosted Kubernetes.
+
+## Sizing
+
+| Shape                           | vCPU | RAM    | Disk      | Fit                                                                                                                                               |
+| ------------------------------- | ---- | ------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Single user / self-host**     | 1    | 2 GB   | 20 GB SSD | Personal use, 1 article at a time                                                                                                                 |
+| **Small team** (2-5 concurrent) | 2-4  | 4-8 GB | 40 GB SSD | Shared dashboard for a pod                                                                                                                        |
+| **Public SaaS**                 | —    | —      | —         | Not supported out of the box. Needs a queue (Redis + BullMQ), per-user API-key isolation, and rate limits. Don't expose `/api/run` synchronously. |
+
+Disk grows with `out/` (markdown + PDFs + downloaded images) and `data.db`
+(run history + CLIP embedding cache). Budget ~10 MB per article.
+
+Memory peaks during the images step (Chromium launched by
+`@topic2md/image-screenshot`): ~300-500 MB extra while it runs.
+
+## Recommended providers
+
+Any of these fit the single-user / small-team shape:
+
+- **[Hetzner Cloud](https://www.hetzner.com/cloud)** CX22 — €4.59/mo, 2 vCPU
+  / 4 GB / 40 GB. Best price/performance in Europe.
+- **Aliyun ECS** (阿里云) t5.small — ¥50-100/mo, 2 vCPU / 2 GB. China-region
+  compliance.
+- **DigitalOcean** Basic Droplet 2 GB — $12/mo, 2 vCPU / 2 GB / 60 GB.
+- **[Fly.io](https://fly.io)** shared-cpu-1x / 1 GB — ~$5/mo, Docker-native
+  deploy via `fly launch`.
+
+## What you need to provide
+
+### 1. Server basics
+
+- Linux VM (Ubuntu 22.04+ or Debian 12+ recommended; Docker-ready)
+- Domain name + DNS A record pointing at the VM
+- TLS certificate (Let's Encrypt via Caddy or certbot — both free)
+- Reverse proxy (Caddy is 2 lines of config; nginx + certbot if you prefer)
+
+### 2. External API keys
+
+| Service        | Required    | Use                                      | Cost at 1 article/day                    |
+| -------------- | ----------- | ---------------------------------------- | ---------------------------------------- |
+| **OpenRouter** | ✅          | LLM gateway (MiniMax / Claude / GPT / …) | ~$3-10/mo with MiniMax M2.7              |
+| **Tavily**     | ✅          | Web research source                      | Free tier 1000 queries/mo; $30/mo paid   |
+| **Replicate**  | recommended | CLIP relevance gate (`jina-clip-v2`)     | ~$5-10/mo after embedding cache kicks in |
+| **Perplexity** | optional    | Alternate research source                | ~$5/mo starter                           |
+| **Langfuse**   | optional    | Observability (per-step traces)          | Free tier or self-host                   |
+
+Accounts take 5-10 min each. Keys go into `.env`. Missing optional keys
+cleanly degrade (Replicate absent → CLIP gate bypasses; Langfuse absent →
+no traces).
+
+### 3. Budget summary (single user)
+
+- VPS: **$5-15/mo**
+- API usage (1 article/day): **$10-25/mo** depending on model and whether
+  Replicate is enabled
+
+**Total: ~$15-40/mo.**
+
+## Docker deployment (recommended)
+
+The repo ships a `Dockerfile` and `docker-compose.yml` that Just Work.
+
+```bash
+# On your VPS, as the deploy user
+git clone https://github.com/LLM-X-Factorer/topic2md.git
+cd topic2md
+cp .env.example .env
+$EDITOR .env                     # fill in OPENROUTER_API_KEY + TAVILY_API_KEY at minimum
+docker compose up -d
+curl -fsS http://localhost:3000  # smoke check
+```
+
+That's it for the app side. The image is based on the official Playwright
+runtime so Chromium + dependencies are baked in.
+
+Images also auto-publish to GHCR from `main`:
+`ghcr.io/llm-x-factorer/topic2md:main`. If you'd rather pull than build:
+
+```yaml
+# docker-compose.yml
+services:
+  topic2md:
+    image: ghcr.io/llm-x-factorer/topic2md:main
+    ports: ['3000:3000']
+    env_file: .env
+    volumes:
+      - ./out:/app/out
+      - ./data.db:/app/data.db
+    restart: unless-stopped
+```
+
+### Persistent volumes — don't skip these
+
+Two paths need to outlive container rebuilds:
+
+- `./out` — generated markdown, PDFs, `_pdf_assets/` image cache
+- `./data.db` (+ `.db-wal` + `.db-shm` sidecars) — run history, CLIP
+  embedding cache
+
+Mount both as volumes in `docker-compose.yml` (already set up in the repo's
+default). Without `data.db` mounted, every container restart loses run
+history and forces Replicate to re-embed every candidate.
+
+## Reverse proxy + TLS
+
+### Caddy (easiest)
+
+Install Caddy, then:
+
+```caddyfile
+topic2md.yourdomain.com {
+    reverse_proxy localhost:3000
+}
+```
+
+That's it. Caddy handles Let's Encrypt automatically.
+
+### nginx + certbot
+
+```nginx
+server {
+    server_name topic2md.yourdomain.com;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Runs are long — bump proxy timeouts from the default 60s
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+}
+```
+
+Then `sudo certbot --nginx -d topic2md.yourdomain.com` to get TLS.
+
+**The `proxy_read_timeout` bump is not optional** — without it, nginx
+closes the connection after 60s and the browser shows an error even though
+the backend is still working.
+
+## Hardening (read this before going public)
+
+The Web UI has **no built-in auth**. If you reverse-proxy it to the public
+internet without changes, anyone who finds the URL can trigger runs that
+hit your OpenRouter / Tavily / Replicate accounts.
+
+Pick at least one of:
+
+1. **Don't expose it publicly.** Bind Docker to `127.0.0.1:3000` and access
+   via SSH tunnel / Tailscale / WireGuard.
+2. **Put it behind basic auth** at the reverse-proxy layer:
+   - Caddy: `basicauth { user HASHED_PASSWORD }`
+   - nginx: `auth_basic` + `htpasswd`
+3. **Add real auth** as a fork. The API surface is `/api/run` — any auth
+   middleware that gates it works.
+
+Other sensible defaults:
+
+- Run Docker as a non-root user (the Playwright base image does this already).
+- `.env` mode `600`, owned by the deploy user, not in git.
+- Set per-run spending alerts in your OpenRouter / Replicate dashboards —
+  a buggy loop + real API keys can get expensive fast.
+- Rotate API keys at least quarterly.
+
+## Observability
+
+`LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY` turn on tracing per run (one
+trace per `runTopic2md` invocation, 6 spans for the workflow steps,
+`generation.*` sub-spans for LLM calls). Absent ⇒ zero overhead.
+
+Self-hosted Langfuse also works — set `LANGFUSE_HOST` to your instance URL.
+
+For just "is the service up?", `GET /` returns the Next.js root and is a
+usable healthcheck. The Dockerfile doesn't ship a `HEALTHCHECK` directive
+yet; add one in your `docker-compose.yml` if you want container-level
+restarts on failure:
+
+```yaml
+healthcheck:
+  test: ['CMD-SHELL', 'curl -fsS http://localhost:3000/ || exit 1']
+  interval: 30s
+  timeout: 5s
+  retries: 3
+```
+
+## Upgrading
+
+```bash
+cd topic2md
+git pull
+docker compose pull         # if using GHCR image
+docker compose up -d        # or `up -d --build` if building locally
+```
+
+Stage bumps go in `CHANGELOG.md`. Watch for any `## Changed` or `## Removed`
+lines when upgrading — those are where user-facing breaks land.
+
+Database migrations are idempotent `ALTER TABLE ADD COLUMN` statements in
+`openDatabase` (see `packages/core/src/persistence.ts`); no manual migration
+step is needed on upgrade.
+
+## Troubleshooting
+
+**Run hangs at "images" for minutes on first Replicate-enabled run.**
+That's the CLIP container cold-starting (~80-120s). Subsequent runs within
+the same hour hit a warm container and complete in seconds. The entry-point
+warmup fires in parallel with research / outline, so the perceived delay is
+smaller than the raw cold-start.
+
+**Run completes but `data.db` doesn't update.**
+Check the volume mount. With `better-sqlite3` the `-wal` and `-shm`
+sidecars need to coexist in the same directory as `data.db`; a bind mount
+on just the `.db` file doesn't work. Mount the parent directory.
+
+**"Replicate HTTP 403" on specific URLs.**
+Some image hosts (e.g. MDPI figures) block Replicate's fetch User-Agent.
+That URL falls through the gate as `score=null` and is dropped — expected
+behavior, not a bug.
+
+**Image step finishes with 0 images attached, but logs show "CLIP gate kept N/M".**
+Vision rerank deliberately rejected all candidates (`pickIndex=-1`) because
+none were a good enough match. The "宁缺毋滥" design preserves the empty
+over a confusing fallback. Rerun with a slightly different `--background`
+or topic phrasing if you need the image.
+
+## Getting help
+
+- Bug? Open a [GitHub issue](https://github.com/LLM-X-Factorer/topic2md/issues)
+  using the bug-report template.
+- Security concern? See [`SECURITY.md`](../SECURITY.md).
+- Want to contribute? [`CONTRIBUTING.md`](../CONTRIBUTING.md).


### PR DESCRIPTION
## Why

Second wave of the open-source hygiene push (follow-up to #29). This PR
closes out the \"medium priority\" docs gaps we identified:

- No changelog — contributors and operators had to read \`git log\` to know
  what shipped between MVP and today.
- Deployment advice was scattered across \`docker-compose.yml\`, \`CLAUDE.md\`,
  a memory note, and recent chat. Anyone cloning the repo and wanting to
  stand up the web UI had to synthesize it themselves.

## What changed

- **\`CHANGELOG.md\`** — Keep a Changelog format. \`[Unreleased]\` stub plus a
  \`[0.2.0] — 2026-04-21\` entry backfilled from git history + project memory,
  grouped Added / Changed / Fixed.
- **\`docs/deployment.md\`** — single-file deployment guide:
  - Not-a-fit list (Vercel / Workers / Netlify — serverless can't handle
    60-200s runs or Playwright Chromium, so it's explicit rather than
    letting someone learn the hard way)
  - Sizing table (single-user / small team / public SaaS)
  - Provider recommendations with prices (Hetzner / Aliyun / DigitalOcean / Fly.io)
  - API-key checklist with per-service monthly cost
  - Docker walkthrough using both local build and GHCR image
  - Caddy + nginx reverse-proxy snippets (with the critical
    \`proxy_read_timeout 300s\` that bites people)
  - Hardening section — the Web UI has no built-in auth, this is called
    out explicitly
  - Observability + upgrade + troubleshooting
- Both READMEs cross-link to the new files.

## How this was verified

- [x] \`pnpm lint\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm format:check\` (prettier autofixed the two new .md files on first pass)
- No behavioral changes.

## Linked issues

None — proactive hygiene.

## Notes for the reviewer

- The 0.2.0 entry in CHANGELOG.md is backfilled rather than cut from a
  single release moment. If you want to actually tag \`v0.2.0\` after merge,
  \`git tag v0.2.0 && git push --tags\` is all it takes; the Docker CI will
  pick it up and publish the versioned image.
- After merge I'll also set the GitHub repo Topics (AI / LLM / Markdown /
  plugins / etc.) and tighten the About line via \`gh repo edit\` — those
  aren't PR-able changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)